### PR TITLE
Make MXE 32bit nsis for 64bit openscad deps, plus other conveniences

### DIFF
--- a/appimage/appimage-x86_64-base/Dockerfile
+++ b/appimage/appimage-x86_64-base/Dockerfile
@@ -4,6 +4,8 @@
 #
 FROM ubuntu:16.04
 
+ARG GITHUB_USER=openscad
+ARG GITHUB_REPO=openscad
 ARG BRANCH=master
 
 RUN \
@@ -22,8 +24,12 @@ RUN \
 
 WORKDIR /openscad
 
+# Invalidate docker cache if the branch changes
+ADD https://api.github.com/repos/${GITHUB_USER}/${GITHUB_REPO}/git/refs/heads/${BRANCH} version.json
+
 RUN \
-	git clone https://github.com/openscad/openscad . && \
+	cat version.json && rm -f version.json && \
+	git clone "https://github.com/${GITHUB_USER}/${GITHUB_REPO}" . && \
 	git checkout "${BRANCH}" && \
 	git rev-parse --abbrev-ref HEAD && \
 	git log -n8 --pretty=tformat:"%h %ai (%aN) %s"

--- a/appimage/appimage-x86_64-openscad/Dockerfile
+++ b/appimage/appimage-x86_64-openscad/Dockerfile
@@ -4,14 +4,20 @@
 #
 FROM openscad/appimage-x86_64-base:latest
 
+ARG GITHUB_USER=openscad
+ARG GITHUB_REPO=openscad
 ARG BRANCH=master
 ARG OPENSCAD_VERSION=
 ARG JOBS=2
 
 WORKDIR /openscad
 
+# Invalidate docker cache if the branch changes
+ADD https://api.github.com/repos/${GITHUB_USER}/${GITHUB_REPO}/git/refs/heads/${BRANCH} version.json
+
 RUN \
-        git clone https://github.com/openscad/openscad . && \
+        cat version.json && rm -f version.json && \
+        git clone "https://github.com/${GITHUB_USER}/${GITHUB_REPO}" . && \
         git checkout "${BRANCH}" && \
         git rev-parse --abbrev-ref HEAD && \
         git log -n8 --pretty=tformat:"%h %ai (%aN) %s"

--- a/mxe/mxe-i686-gcc/Dockerfile
+++ b/mxe/mxe-i686-gcc/Dockerfile
@@ -21,4 +21,4 @@ RUN \
 	git rev-parse --abbrev-ref HEAD && \
 	git log -n8 --pretty=tformat:"%h %ai (%aN) %s"
 RUN \
-	make "JOBS=${JOBS}" "-j${JOBS}" MXE_PLUGIN_DIRS=plugins/gcc7 MXE_TARGETS=i686-w64-mingw32.static.posix gcc
+	make "JOBS=${JOBS}" "-j${JOBS}" MXE_PLUGIN_DIRS=plugins/gcc7 MXE_TARGETS=i686-w64-mingw32.static.posix cc

--- a/mxe/mxe-i686-openscad/Dockerfile
+++ b/mxe/mxe-i686-openscad/Dockerfile
@@ -5,19 +5,28 @@
 FROM openscad/mxe-i686-deps:latest
 
 ARG SUFFIX=
+ARG GITHUB_USER=openscad
+ARG GITHUB_REPO=openscad
 ARG BRANCH=master
 ARG OPENSCAD_VERSION=
+ARG JOBS=2
 
 WORKDIR /openscad
+
+# Invalidate docker cache if the branch changes
+ADD https://api.github.com/repos/${GITHUB_USER}/${GITHUB_REPO}/git/refs/heads/${BRANCH} version.json
+
 RUN \
-	git clone https://github.com/openscad/openscad . && \
+	cat version.json && rm -f version.json && \
+	git clone "https://github.com/${GITHUB_USER}/${GITHUB_REPO}" . && \
 	git checkout "${BRANCH}" && \
 	git rev-parse --abbrev-ref HEAD && \
 	git log -n8 --pretty=tformat:"%h %ai (%aN) %s"
 RUN \
 	export MXEDIR=/mxe ; \
+	export NUMCPU="$JOBS" ; \
 	export LIB3MF_INCLUDEPATH=/mxe/usr/i686-w64-mingw32.static.posix/include/lib3mf ; \
-	. ./scripts/setenv-mingw-xbuild.sh 32 && ./scripts/release-common.sh -snapshot -mingw32 -v "$OPENSCAD_VERSION"; \
+	./scripts/release-common.sh -snapshot -mingw32 -v "$OPENSCAD_VERSION"; \
 	mkdir -p out; \
 	for f in mingw*/*.zip mingw*/*.exe; do \
 		N=$(basename "$f" | sed -e "s/\\(-x86-[36][24]\\)/\\1${SUFFIX}/;"); \

--- a/mxe/mxe-i686-openscad/Dockerfile
+++ b/mxe/mxe-i686-openscad/Dockerfile
@@ -26,7 +26,7 @@ RUN \
 	export MXEDIR=/mxe ; \
 	export NUMCPU="$JOBS" ; \
 	export LIB3MF_INCLUDEPATH=/mxe/usr/i686-w64-mingw32.static.posix/include/lib3mf ; \
-	./scripts/release-common.sh -snapshot -mingw32 -v "$OPENSCAD_VERSION"; \
+	./scripts/release-common.sh snapshot mingw32 -v "$OPENSCAD_VERSION"; \
 	mkdir -p out; \
 	for f in mingw*/*.zip mingw*/*.exe; do \
 		N=$(basename "$f" | sed -e "s/\\(-x86-[36][24]\\)/\\1${SUFFIX}/;"); \

--- a/mxe/mxe-x86_64-deps/Dockerfile
+++ b/mxe/mxe-x86_64-deps/Dockerfile
@@ -8,6 +8,7 @@ ARG JOBS=2
 
 WORKDIR /mxe
 
+# use 32bit makensis from MXE. 64bit version not compatible
 RUN \
 	make "JOBS=${JOBS}" "-j${JOBS}" \
 		MXE_PLUGIN_DIRS=plugins/gcc7 \
@@ -15,5 +16,9 @@ RUN \
 		qtbase qtmultimedia qtgamepad qscintilla2 \
 		opencsg cgal mpfr eigen \
 		libxml2 freetype fontconfig harfbuzz \
-		glib libzip lib3mf nsis double-conversion && \
+		glib libzip lib3mf double-conversion && \
+	make "JOBS=${JOBS}" "-j${JOBS}" \
+		MXE_PLUGIN_DIRS=plugins/gcc7 \
+		MXE_TARGETS=i686-w64-mingw32.static.posix \
+		nsis && \
 	make MXE_PLUGIN_DIRS=plugins/gcc7 clean-junk

--- a/mxe/mxe-x86_64-gcc/Dockerfile
+++ b/mxe/mxe-x86_64-gcc/Dockerfile
@@ -21,4 +21,4 @@ RUN \
 	git rev-parse --abbrev-ref HEAD && \
 	git log -n8 --pretty=tformat:"%h %ai (%aN) %s"
 RUN \
-	make "JOBS=${JOBS}" "-j${JOBS}" MXE_PLUGIN_DIRS=plugins/gcc7 MXE_TARGETS=x86_64-w64-mingw32.static.posix gcc
+	make "JOBS=${JOBS}" "-j${JOBS}" MXE_PLUGIN_DIRS=plugins/gcc7 MXE_TARGETS=x86_64-w64-mingw32.static.posix cc

--- a/mxe/mxe-x86_64-openscad/Dockerfile
+++ b/mxe/mxe-x86_64-openscad/Dockerfile
@@ -26,7 +26,7 @@ RUN \
 	export MXEDIR=/mxe ; \
 	export NUMCPU="$JOBS" ; \
 	export LIB3MF_INCLUDEPATH=/mxe/usr/x86_64-w64-mingw32.static.posix/include/lib3mf ; \
-	./scripts/release-common.sh -snapshot -mingw64 -v "$OPENSCAD_VERSION"; \
+	./scripts/release-common.sh snapshot mingw64 -v "$OPENSCAD_VERSION"; \
 	mkdir -p out; \
 	for f in mingw*/*.zip mingw*/*.exe; do \
 		N=$(basename "$f" | sed -e "s/\\(-x86-[36][24]\\)/\\1${SUFFIX}/;"); \

--- a/mxe/mxe-x86_64-openscad/Dockerfile
+++ b/mxe/mxe-x86_64-openscad/Dockerfile
@@ -5,19 +5,28 @@
 FROM openscad/mxe-x86_64-deps:latest
 
 ARG SUFFIX=
+ARG GITHUB_USER=openscad
+ARG GITHUB_REPO=openscad
 ARG BRANCH=master
 ARG OPENSCAD_VERSION=
+ARG JOBS=2
 
 WORKDIR /openscad
+
+# Invalidate docker cache if the branch changes
+ADD https://api.github.com/repos/${GITHUB_USER}/${GITHUB_REPO}/git/refs/heads/${BRANCH} version.json
+
 RUN \
-	git clone https://github.com/openscad/openscad . && \
+	cat version.json && rm -f version.json && \
+	git clone "https://github.com/${GITHUB_USER}/${GITHUB_REPO}" . && \
 	git checkout "${BRANCH}" && \
 	git rev-parse --abbrev-ref HEAD && \
 	git log -n8 --pretty=tformat:"%h %ai (%aN) %s"
 RUN \
 	export MXEDIR=/mxe ; \
+	export NUMCPU="$JOBS" ; \
 	export LIB3MF_INCLUDEPATH=/mxe/usr/x86_64-w64-mingw32.static.posix/include/lib3mf ; \
-	. ./scripts/setenv-mingw-xbuild.sh 64 && ./scripts/release-common.sh -snapshot -mingw64 -v "$OPENSCAD_VERSION"; \
+	./scripts/release-common.sh -snapshot -mingw64 -v "$OPENSCAD_VERSION"; \
 	mkdir -p out; \
 	for f in mingw*/*.zip mingw*/*.exe; do \
 		N=$(basename "$f" | sed -e "s/\\(-x86-[36][24]\\)/\\1${SUFFIX}/;"); \


### PR DESCRIPTION
`openscad/scripts/release-common.sh` script currently finds `makensis` package v2.51 which is installed from debian stretch.  MXE has version 3.01 (for 32bit only), which supports Unicode attribute, making it possible to install to paths that have extended characters (or package files with unicode in names if we chose to).