### PR TITLE
Add opengl images

### DIFF
--- a/openscad/focal/Dockerfile
+++ b/openscad/focal/Dockerfile
@@ -1,0 +1,81 @@
+FROM ubuntu:20.04 AS builder
+
+ARG GITHUB_USER=openscad
+ARG GITHUB_REPO=openscad
+ARG BRANCH=master
+ARG REFS=heads
+ARG OPENSCAD_VERSION=
+ARG SNAPSHOT=+
+ARG DEBUG=-
+ARG JOBS=1
+ARG COMMIT=true
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update
+
+RUN apt-get -y full-upgrade
+
+# Base setup
+RUN apt-get install -y --no-install-recommends \
+	apt-utils apt-transport-https ca-certificates git wget jq
+
+# Dev dependencies
+RUN apt-get -y install --no-install-recommends \
+	build-essential curl libffi-dev libxmu-dev cmake bison flex \
+	git-core libboost-all-dev libmpfr-dev libboost-dev libglew-dev \
+	libcairo2-dev libeigen3-dev libcgal-dev libopencsg-dev libgmp3-dev \
+	libgmp-dev imagemagick libfreetype6-dev libdouble-conversion-dev \
+	gtk-doc-tools libglib2.0-dev gettext pkg-config ragel libxi-dev \
+	libfontconfig-dev libzip-dev lib3mf-dev libharfbuzz-dev libxml2-dev \
+	qtbase5-dev libqt5scintilla2-dev libqt5opengl5-dev libqt5svg5-dev \
+	qtmultimedia5-dev libqt5multimedia5-plugins qt5-default
+
+WORKDIR /openscad
+
+# Invalidate docker cache if the branch changes
+ADD https://api.github.com/repos/${GITHUB_USER}/${GITHUB_REPO}/git/refs/${REFS}/${BRANCH} version.json
+
+RUN \
+        cat version.json | jq . && rm -f version.json && \
+        git clone "https://github.com/${GITHUB_USER}/${GITHUB_REPO}" . && \
+        git checkout "${BRANCH}" && \
+        git rev-parse --abbrev-ref HEAD && \
+        git log -n8 --pretty=tformat:"%h %ai (%aN) %s"
+
+RUN \
+	git submodule update --init && \
+        export OPENSCAD_COMMIT=$(/bin/"$COMMIT" && git log -1 --pretty=format:%h || echo "") && \
+	qmake -v && \
+	qmake -d \
+		PREFIX=/usr/local \
+		VERSION="$OPENSCAD_VERSION" \
+		OPENSCAD_COMMIT="$OPENSCAD_COMMIT" \
+		CONFIG+=qopenglwidget \
+		CONFIG${SNAPSHOT}=experimental \
+		CONFIG${SNAPSHOT}=snapshot \
+		CONFIG${DEBUG}=debug && \
+        make -j"$JOBS"
+
+RUN make install INSTALL_ROOT=/
+
+FROM ubuntu:20.04
+
+RUN apt-get update
+
+RUN apt-get -y full-upgrade
+
+RUN apt-get install -y --no-install-recommends \
+	libcairo2 libdouble-conversion3 libxml2 lib3mf1 libzip5 libharfbuzz0b \
+	libboost-thread1.67.0 libboost-program-options1.67.0 libboost-filesystem1.67.0 \
+	libboost-regex1.67.0 libglew2.1 libopencsg1 libmpfr6 libqscintilla2-qt5-15 \
+	libqt5multimedia5 libqt5concurrent5 libcgal-dev libglu1-mesa xvfb xauth \
+	libboost-filesystem1.71.0 libboost-regex1.71.0
+
+RUN apt-get clean
+
+WORKDIR /usr/local
+
+COPY --from=builder /usr/local/ .
+
+WORKDIR /openscad

--- a/openscad/focal/Dockerfile.opengl
+++ b/openscad/focal/Dockerfile.opengl
@@ -1,4 +1,4 @@
-FROM debian:buster-slim AS builder
+FROM nvidia/opengl:1.0-glvnd-runtime-ubuntu20.04 AS builder
 
 ARG GITHUB_USER=openscad
 ARG GITHUB_REPO=openscad
@@ -7,7 +7,7 @@ ARG REFS=heads
 ARG OPENSCAD_VERSION=
 ARG SNAPSHOT=+
 ARG DEBUG=-
-ARG JOBS=2
+ARG JOBS=1
 ARG COMMIT=true
 
 ENV DEBIAN_FRONTEND=noninteractive
@@ -59,17 +59,18 @@ RUN \
 
 RUN make install INSTALL_ROOT=/
 
-FROM debian:buster-slim
+FROM nvidia/opengl:1.0-glvnd-runtime-ubuntu20.04
 
 RUN apt-get update
 
 RUN apt-get -y full-upgrade
 
 RUN apt-get install -y --no-install-recommends \
-	libcairo2 libdouble-conversion1 libxml2 lib3mf1 libzip4 libharfbuzz0b \
+	libcairo2 libdouble-conversion3 libxml2 lib3mf1 libzip5 libharfbuzz0b \
 	libboost-thread1.67.0 libboost-program-options1.67.0 libboost-filesystem1.67.0 \
-	libboost-regex1.67.0 libglew2.1 libopencsg1 libmpfr6 libqscintilla2-qt5-13 \
-	libqt5multimedia5 libqt5concurrent5 libcgal13 libglu1-mesa xvfb xauth
+	libboost-regex1.67.0 libglew2.1 libopencsg1 libmpfr6 libqscintilla2-qt5-15 \
+	libqt5multimedia5 libqt5concurrent5 libcgal-dev libglu1-mesa xvfb xauth \
+	libboost-filesystem1.71.0 libboost-regex1.71.0
 
 RUN apt-get clean
 

--- a/scripts/build-images.sh
+++ b/scripts/build-images.sh
@@ -22,15 +22,18 @@ build () {
 		--build-arg=REFS="$REF" \
 		--build-arg=BRANCH="$BRANCH" \
 		--build-arg OPENSCAD_VERSION="$VERSION" \
+		--build-arg JOBS="1" \
 		$DOCKERFILE_ARGS \
 		"$DIR"
 }
 
 V=$(git log -1 --date="format:%Y.%m.%d.dd%j%H" --format="%cd")
 
-#build	tags	openscad-2015.03	2015.03	""	openscad/buster
-build	tags	openscad-2019.05	2019.05	""	openscad/buster
-build	tags	openscad-2021.01	2021.01	""	openscad/buster
+#build	tags	openscad-2015.03	2015.03	      ""	openscad/buster
+build	tags	openscad-2019.05	2019.05	      ""	openscad/buster
+build	tags	openscad-2021.01	2021.01	      ""	openscad/buster
+build   tags    openscad-2021.01    2021.01-focal ""  openscad/focal Dockerfile
+
 build	heads	master			dev	"$V"	openscad/bookworm
 
 docker tag openscad/openscad:2021.01 openscad/openscad:latest

--- a/scripts/build-images.sh
+++ b/scripts/build-images.sh
@@ -29,11 +29,11 @@ build () {
 
 V=$(git log -1 --date="format:%Y.%m.%d.dd%j%H" --format="%cd")
 
-#build	tags	openscad-2015.03	2015.03	      ""	openscad/buster
-build	tags	openscad-2019.05	2019.05	      ""	openscad/buster
-build	tags	openscad-2021.01	2021.01	      ""	openscad/buster
-build   tags    openscad-2021.01    2021.01-focal ""  openscad/focal Dockerfile
-
+#build	tags	openscad-2015.03	2015.03	      		 ""	openscad/buster
+build	tags	openscad-2019.05	2019.05	      		 ""	openscad/buster
+build	tags	openscad-2021.01	2021.01	      		 ""	openscad/buster
+build   tags    openscad-2021.01    2021.01-focal 		 "" openscad/focal Dockerfile
+build   tags    openscad-2021.01    2021.01-focal-opengl "" openscad/focal Dockerfile.opengl
 build	heads	master			dev	"$V"	openscad/bookworm
 
-docker tag openscad/openscad:2021.01 openscad/openscad:latest
+# docker tag openscad/openscad:2021.01 openscad/openscad:latest


### PR DESCRIPTION
I'm attempting to troubleshoot a problem where [openscad crashes but only when running in docker](https://github.com/openscad/openscad/issues/4028#issuecomment-1003270333). It seems to be related to opengl. 

To troubleshoot, I built images based on `nvidia/opengl` docker container. 

While the bug is still present in the `nvidia/opengl` so these containers weren't necessary, I'm sharing this dockerfile in case it is useful to anyone else. 

- https://techsparx.com/software-development/docker/display-x11-apps.html
- https://medium.com/@benjamin.botto/opengl-and-cuda-applications-in-docker-af0eece000f1