### PR TITLE
MXE updates

### DIFF
--- a/mxe/mxe-i686-deps/Dockerfile
+++ b/mxe/mxe-i686-deps/Dockerfile
@@ -9,14 +9,14 @@ ARG JOBS=2
 WORKDIR /mxe
 
 RUN \
-	make "JOBS=${JOBS}" "-j${JOBS}" \
-		MXE_PLUGIN_DIRS=plugins/gcc11 \
-		MXE_TARGETS=i686-w64-mingw32.static.posix \
-		mpfr \
-                eigen \
-                libxml2 \
-                freetype \
-                fontconfig \
-                harfbuzz \
-	&& \
-	make MXE_PLUGIN_DIRS=plugins/gcc11 clean-junk
+  make "JOBS=${JOBS}" "-j${JOBS}" \
+    MXE_PLUGIN_DIRS=plugins/gcc11 \
+    MXE_TARGETS=i686-w64-mingw32.static.posix \
+      mpfr \
+      eigen \
+      libxml2 \
+      freetype \
+      fontconfig \
+      harfbuzz \
+  && \
+  make MXE_PLUGIN_DIRS=plugins/gcc11 clean-junk

--- a/mxe/mxe-i686-deps2/Dockerfile
+++ b/mxe/mxe-i686-deps2/Dockerfile
@@ -9,14 +9,14 @@ ARG JOBS=2
 WORKDIR /mxe
 
 RUN \
-	make "JOBS=${JOBS}" "-j${JOBS}" \
-		MXE_PLUGIN_DIRS=plugins/gcc11 \
-		MXE_TARGETS=i686-w64-mingw32.static.posix \
-                cairo \
-                glib \
-                libzip \
-                lib3mf \
-                double-conversion \
-		nsis \
-		&& \
-	make MXE_PLUGIN_DIRS=plugins/gcc11 clean-junk
+  make "JOBS=${JOBS}" "-j${JOBS}" \
+    MXE_PLUGIN_DIRS=plugins/gcc11 \
+    MXE_TARGETS=i686-w64-mingw32.static.posix \
+      cairo \
+      glib \
+      libzip \
+      lib3mf \
+      double-conversion \
+      nsis \
+  && \
+  make MXE_PLUGIN_DIRS=plugins/gcc11 clean-junk

--- a/mxe/mxe-requirements/Dockerfile
+++ b/mxe/mxe-requirements/Dockerfile
@@ -6,4 +6,4 @@ FROM buildpack-deps:buster
 
 RUN apt-get update
 
-RUN apt-get install -y --no-install-recommends autopoint bison flex gperf libtool ruby scons unzip p7zip-full intltool libtool libtool-bin nsis zip lzip gnupg
+RUN apt-get install -y --no-install-recommends autopoint bison flex gperf libtool ninja-build ruby scons unzip p7zip-full intltool libtool libtool-bin zip lzip gnupg

--- a/mxe/mxe-x86_64-deps/Dockerfile
+++ b/mxe/mxe-x86_64-deps/Dockerfile
@@ -9,14 +9,14 @@ ARG JOBS=2
 WORKDIR /mxe
 
 RUN \
-	make "JOBS=${JOBS}" "-j${JOBS}" \
-		MXE_PLUGIN_DIRS=plugins/gcc11 \
-		MXE_TARGETS=x86_64-w64-mingw32.static.posix \
-                mpfr \
-                eigen \
-		libxml2 \
-                freetype \
-                fontconfig \
-                harfbuzz \
-		&& \
-	make MXE_PLUGIN_DIRS=plugins/gcc11 clean-junk
+  make "JOBS=${JOBS}" "-j${JOBS}" \
+    MXE_PLUGIN_DIRS=plugins/gcc11 \
+    MXE_TARGETS=x86_64-w64-mingw32.static.posix \
+      mpfr \
+      eigen \
+      libxml2 \
+      freetype \
+      fontconfig \
+      harfbuzz \
+    && \
+  make MXE_PLUGIN_DIRS=plugins/gcc11 clean-junk

--- a/mxe/mxe-x86_64-deps2/Dockerfile
+++ b/mxe/mxe-x86_64-deps2/Dockerfile
@@ -9,13 +9,14 @@ ARG JOBS=2
 WORKDIR /mxe
 
 RUN \
-	make "JOBS=${JOBS}" "-j${JOBS}" \
-		MXE_PLUGIN_DIRS=plugins/gcc11 \
-		MXE_TARGETS=x86_64-w64-mingw32.static.posix \
-                cairo \
-		glib \
-                libzip \
-                lib3mf \
-                double-conversion \
-	&& \
-	make MXE_PLUGIN_DIRS=plugins/gcc11 clean-junk
+  make "JOBS=${JOBS}" "-j${JOBS}" \
+    MXE_PLUGIN_DIRS=plugins/gcc11 \
+    MXE_TARGETS=x86_64-w64-mingw32.static.posix \
+      cairo \
+      glib \
+      libzip \
+      lib3mf \
+      double-conversion \
+      nsis \
+  && \
+  make MXE_PLUGIN_DIRS=plugins/gcc11 clean-junk

--- a/mxe/mxe-x86_64-gcc/Dockerfile
+++ b/mxe/mxe-x86_64-gcc/Dockerfile
@@ -11,16 +11,9 @@ ARG GITHUB_REPO=mxe
 
 WORKDIR /mxe
 
-# use 32bit makensis from MXE. 64bit version not compatible
-# for that we use the i686-gcc base image which provides the
-# already built gcc
 RUN \
-	make "JOBS=${JOBS}" "-j${JOBS}" \
-                MXE_PLUGIN_DIRS=plugins/gcc11 \
-                MXE_TARGETS=x86_64-w64-mingw32.static.posix \
-                cc && \
-	make "JOBS=${JOBS}" "-j${JOBS}" \
-		MXE_PLUGIN_DIRS=plugins/gcc11 \
-		MXE_TARGETS=i686-w64-mingw32.static.posix \
-		nsis && \
-	make MXE_PLUGIN_DIRS=plugins/gcc11 clean-junk
+  make "JOBS=${JOBS}" "-j${JOBS}" \
+    MXE_PLUGIN_DIRS=plugins/gcc11 \
+    MXE_TARGETS=x86_64-w64-mingw32.static.posix \
+      cc && \
+  make MXE_PLUGIN_DIRS=plugins/gcc11 clean-junk


### PR DESCRIPTION
Add debian ninja-build package.
Use nsis from mxe for both 32 and 64 bit builds.
Fixed various mixed tab/spaces.