### PR TITLE
multi-stage build

### DIFF
--- a/appimage/appimage-x86_64-base/Dockerfile
+++ b/appimage/appimage-x86_64-base/Dockerfile
@@ -203,7 +203,7 @@ WORKDIR /openscad
 
 ARG OPENSCAD_COMMIT=cfdd775c439094698f1c6e5595b7574f636af4da
 ARG SNAPSHOT=ON
-ARG JOBS=2
+ARG JOBS=4
 
 RUN \
     git clone "https://github.com/openscad/openscad" . && \


### PR DESCRIPTION
Using a multi-stage build like this has the advantage of not invalidating caches for dependencies that don't change.

However, I don't think that it's a good idea to have this code in a different repo. I think it only makes the whole CI process more unnecessarily complicated.

Testing: the build passes, I have not tried running the AppImage. I would not consider this ready to review on anything but the highest level; does this general approach look interesting?

Specific stages can be pulled out into their own tags: `docker build --target openscad-appimage-x86_64-base -t openscad/appimage-x86_64-base .` for example will tag the base image.