### PR TITLE
Add RISC-V 64-bit (riscv64) support

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,9 +67,11 @@ docker stop openscad-gui && docker rm openscad-gui
 
 ## CI support, for internal use
 
-* `openscad/appimage-*`
+* `openscad/appimage-*` (x86\_64, arm64v8, riscv64)
 * `openscad/mxe-*`
 * `openscad/src-*`
+
+The trixie-based Docker images and AppImage builds support linux/amd64, linux/arm64, and linux/riscv64.
 
 All docker images can be viewed with a [Docker Hub search for `openscad/`](https://hub.docker.com/search?q=openscad%2F&image_filter=open_source&type=image).
 

--- a/appimage/appimage-riscv64-base/Dockerfile
+++ b/appimage/appimage-riscv64-base/Dockerfile
@@ -1,0 +1,70 @@
+#
+# Build: docker build -t openscad/appimage-riscv64-base .
+# Use: docker run --rm -it -v openscad/appimage-riscv64-base
+#
+FROM riscv64/ubuntu:24.04
+
+ARG GITHUB_USER=openscad
+ARG GITHUB_REPO=openscad
+ARG BRANCH=master
+ARG JOBS=2
+
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN \
+	apt-get update && \
+	apt-get upgrade -y && \
+	apt-get install -y --no-install-recommends \
+		apt-utils apt-transport-https ca-certificates git wget \
+		patchelf gnupg ccache appstream xxd desktop-file-utils \
+		libjpeg-dev cimg-dev libcairo-dev libfuse-dev libssl-dev \
+		libgpgme-dev libgcrypt20-dev clang ninja-build \
+		itstool cmake \
+		&& \
+	apt-get clean
+
+RUN \
+	apt-get update && \
+	apt-get install -y --no-install-recommends libcgal-dev && \
+	apt-get clean
+
+WORKDIR /openscad
+
+# Invalidate docker cache if the branch changes
+ADD https://api.github.com/repos/${GITHUB_USER}/${GITHUB_REPO}/git/refs/heads/${BRANCH} version.json
+
+RUN \
+	cat version.json && rm -f version.json && \
+	git clone "https://github.com/${GITHUB_USER}/${GITHUB_REPO}" . && \
+	git checkout "${BRANCH}" && \
+	git rev-parse --abbrev-ref HEAD && \
+	git log -n8 --pretty=tformat:"%h %ai (%aN) %s" && \
+	bash ./scripts/uni-get-dependencies.sh && \
+	bash ./scripts/check-dependencies.sh && \
+	(apt-get install -y lib3mf-dev || /bin/true) && \
+	cd / && apt-get clean && rm -rf /openscad
+
+WORKDIR /appimage
+
+RUN \
+	git clone --single-branch --recursive https://github.com/linuxdeploy/linuxdeploy.git && \
+	git clone --single-branch --recursive https://github.com/linuxdeploy/linuxdeploy-plugin-qt.git && \
+	git clone --single-branch --recursive https://github.com/linuxdeploy/linuxdeploy-plugin-appimage.git && \
+	git clone --single-branch --recursive https://github.com/AppImage/AppImageKit.git
+
+RUN \
+	cd /appimage/linuxdeploy/ && mkdir build && cd build/ && cmake -DCMAKE_INSTALL_PREFIX=/appimage/usr -DCMAKE_BUILD_TYPE=RelWithDebInfo .. && make -j"$JOBS" && make install && \
+        cd /appimage && mkdir -p usr/bin/ && cp linuxdeploy/build/bin/linuxdeploy usr/bin/
+
+RUN \
+	cd /appimage/linuxdeploy-plugin-qt/ && mkdir build && cd build/ && cmake -DCMAKE_INSTALL_PREFIX=/appimage/usr -DCMAKE_BUILD_TYPE=RelWithDebInfo .. && make -j"$JOBS" && make install
+
+RUN \
+	cd /appimage/linuxdeploy-plugin-appimage && mkdir build && cd build/ && cmake -DCMAKE_INSTALL_PREFIX=/appimage/usr -DCMAKE_BUILD_TYPE=RelWithDebInfo .. && make -j"$JOBS" && make install
+
+RUN \
+	cd /appimage/AppImageKit && mkdir build && cd build/ && cmake -DCMAKE_INSTALL_PREFIX=/appimage/usr -DCMAKE_BUILD_TYPE=RelWithDebInfo -DBUILD_TESTING=OFF -DAPPIMAGEKIT_PACKAGE_DEBS=OFF .. && make -j"$JOBS" && make install
+
+RUN \
+	rm -rf linuxdeploy linuxdeploy-plugin-qt linuxdeploy-plugin-appimage AppImageKit && \
+	find /appimage

--- a/appimage/appimage-riscv64-openscad/Dockerfile
+++ b/appimage/appimage-riscv64-openscad/Dockerfile
@@ -1,0 +1,54 @@
+#
+# Build: docker build -t openscad/appimage-riscv64-openscad .
+# Use: docker run --rm -it -v openscad/appimage-riscv64-openscad
+#
+FROM openscad/appimage-riscv64-base:latest
+
+ARG GITHUB_USER=openscad
+ARG GITHUB_REPO=openscad
+ARG BRANCH=master
+ARG REFS=heads
+ARG OPENSCAD_VERSION=
+ARG BUILD_TYPE=Release
+ARG SNAPSHOT=ON
+ARG JOBS=2
+ARG COMMIT=true
+
+WORKDIR /openscad
+
+# Invalidate docker cache if the branch changes
+ADD https://api.github.com/repos/${GITHUB_USER}/${GITHUB_REPO}/git/refs/${REFS}/${BRANCH} version.json
+
+RUN \
+	cat version.json && rm -f version.json && \
+	git clone --recursive --single-branch --branch "${BRANCH}" --shallow-submodules "https://github.com/${GITHUB_USER}/${GITHUB_REPO}" . && \
+	git rev-parse --abbrev-ref HEAD && \
+	git log -n8 --pretty=tformat:"%h %ai (%aN) %s"
+
+RUN \
+	export OPENSCAD_COMMIT=$(/bin/"$COMMIT" && git log -1 --pretty=format:%h || echo "") && \
+	mkdir build && \
+	cd build && \
+	cmake .. \
+		-GNinja \
+		-DENABLE_TESTS=OFF \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
+		-DOpenGL_GL_PREFERENCE=LEGACY \
+		-DEXPERIMENTAL=${SNAPSHOT} \
+		-DSNAPSHOT=${SNAPSHOT} \
+		-DOPENSCAD_VERSION="$OPENSCAD_VERSION" \
+		-DOPENSCAD_COMMIT="$OPENSCAD_COMMIT" \
+		&& \
+	cmake --build . "-j$JOBS" -v
+
+RUN \
+	cmake --install build --prefix=AppDir/usr -v
+
+RUN \
+	export PATH=/appimage/usr/bin:"$PATH" && \
+	VERSION="${OPENSCAD_VERSION:-$(date +%Y.%m.%d).ai}" linuxdeploy --plugin qt --output appimage --appdir AppDir && \
+	mkdir -p out && \
+	cp -iv OpenSCAD*.AppImage out/
+
+ENTRYPOINT tar --create -C /openscad/out .

--- a/openscad/trixie/hooks/build
+++ b/openscad/trixie/hooks/build
@@ -12,7 +12,7 @@ dmidecode -t system || /bin/true
 docker buildx build \
 	--push \
 	--progress plain \
-	--platform linux/amd64,linux/arm64 \
+	--platform linux/amd64,linux/arm64,linux/riscv64 \
 	--build-arg REFS="heads" \
 	--build-arg BRANCH="master" \
 	--build-arg OPENSCAD_VERSION="$VERSION" \

--- a/openscad/trixie/hooks/pre_build
+++ b/openscad/trixie/hooks/pre_build
@@ -5,6 +5,6 @@ export DOCKER_BUILDKIT=1
 docker buildx create \
 	--name builder \
 	--driver docker-container \
-	--platform linux/amd64,linux/arm64 \
+	--platform linux/amd64,linux/arm64,linux/riscv64 \
 	--use
 docker buildx inspect --bootstrap

--- a/scripts/build-appimage.sh
+++ b/scripts/build-appimage.sh
@@ -14,4 +14,7 @@ build appimage openscad/appimage-x86_64-openscad
 build appimage openscad/appimage-arm64v8-base
 build appimage openscad/appimage-arm64v8-openscad
 
+build appimage openscad/appimage-riscv64-base
+build appimage openscad/appimage-riscv64-openscad
+
 list 'openscad/appimage-*'

--- a/scripts/build-images.sh
+++ b/scripts/build-images.sh
@@ -11,6 +11,7 @@ build () {
 	DIR="$6"
 	FILE="$7"
 	FILTER="$8"
+	PLATFORM="${9:-linux/amd64,linux/arm64}"
 
 	if [ -z "$FILTER" ]
 	then
@@ -45,7 +46,7 @@ build () {
 	docker buildx build \
 		--push \
 		--progress=plain \
-		--platform linux/amd64,linux/arm64 \
+		--platform $PLATFORM \
 		--build-arg=REFS="$REF" \
 		--build-arg=BRANCH="$BRANCH" \
 		--build-arg OPENSCAD_VERSION="$VERSION" \
@@ -67,6 +68,6 @@ build	tags	openscad-2021.01	2021.01		latest	""	openscad/buster		Dockerfile	"${1-
 build	heads	master			bookworm	""	"$V"	openscad/bookworm	Dockerfile	"${1-}"
 build	heads	master			bookworm-egl	egl	"$V"	openscad/bookworm	Dockerfile.egl	"${1-}"
 
-build	heads	master			trixie		dev	"$V"	openscad/trixie		Dockerfile	"${1-}"
+build	heads	master			trixie		dev	"$V"	openscad/trixie		Dockerfile	"${1-}"	linux/amd64,linux/arm64,linux/riscv64
 
 docker image list -f 'reference=openscad/openscad'

--- a/scripts/docker-build-release.sh
+++ b/scripts/docker-build-release.sh
@@ -50,6 +50,7 @@ main () {
 	echo "2) MXE 64-bit"
 	echo "3) AppImage x86 64-bit"
 	echo "4) AppImage ARM 64-bit"
+	echo "5) AppImage RISC-V 64-bit"
 	echo ""
 	echo "9) Sources"
 	echo ""
@@ -74,6 +75,10 @@ main () {
 		4)
 			build openscad/appimage-arm64v8-openscad appimage/appimage-arm64v8-openscad/ --build-arg SNAPSHOT=-
 			run openscad/appimage-arm64v8-openscad
+			;;
+		5)
+			build openscad/appimage-riscv64-openscad appimage/appimage-riscv64-openscad/ --build-arg SNAPSHOT=-
+			run openscad/appimage-riscv64-openscad
 			;;
 		9)
 			build openscad/src-openscad src/src-openscad --build-arg TAG="${BRANCH}"


### PR DESCRIPTION
## Summary

Add RISC-V 64-bit architecture support to the Docker build infrastructure for trixie-based builds and AppImage generation.

## Changes

- Add `linux/riscv64` to trixie buildx platform list in `hooks/pre_build` and `hooks/build`
- Add optional platform parameter to `build-images.sh` build function (defaults to amd64+arm64, trixie passes amd64+arm64+riscv64)
- Add `appimage-riscv64-base` Dockerfile based on `riscv64/ubuntu:24.04` (Noble — first Ubuntu with official riscv64 support)
- Add `appimage-riscv64-openscad` Dockerfile based on the arm64v8 template
- Add riscv64 entries to `build-appimage.sh` and menu option 5 to `docker-build-release.sh`
- Update README to document riscv64 support

## Issue Linking

No existing issue, this was discussed via email with @t-paul (Oct 2024, discuss@lists.openscad.org).

## Testing

- [ ] Verify trixie Docker image builds with `docker buildx build --platform linux/riscv64 -f openscad/trixie/Dockerfile --build-arg JOBS=2 .`
- [ ] Verify AppImage base Dockerfile parses correctly: `docker buildx build --platform linux/riscv64 -f appimage/appimage-riscv64-base/Dockerfile --check .`
- [ ] Verify existing amd64/arm64 builds are not affected (platform lists are additive, older builds use the default)

## Checklist

- [x] Code follows project conventions
- [x] Files end with empty line for cross-platform compatibility
- [x] Documentation updated
- [x] Bookworm and older builds left unchanged (riscv64 Debian support was limited before Trixie)

## Notes

### Notable differences from arm64v8 AppImage base

The riscv64 base uses Ubuntu 24.04 instead of 20.04, which means:
- CGAL comes from distro packages (Noble ships CGAL 5.6) rather than the OBS repository
- cmake comes from distro packages (Noble ships cmake 3.28) rather than the Kitware PPA
- No need for `clang-12` — Noble ships a newer clang by default

### Background

I have been building and publishing multi-arch OpenSCAD Docker images at https://hub.docker.com/r/gounthar/openscad and riscv64 binaries and OS packages at https://github.com/gounthar/openscad/releases. This PR formalizes RISC-V support in the official build infrastructure.